### PR TITLE
feat: transform ntl to ytl

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,15 @@
-# ntl
+# ytl
 
-[![NPM version](https://badge.fury.io/js/ntl.svg)](https://npmjs.org/package/ntl)
+<!-- [![NPM version](https://badge.fury.io/js/ntl.svg)](https://npmjs.org/package/ytl)
 [![Build Status](https://travis-ci.org/ruyadorno/ntl.svg?branch=master)](https://travis-ci.org/ruyadorno/ntl)
 [![License](http://img.shields.io/badge/license-MIT-blue.svg?style=flat)](https://raw.githubusercontent.com/ruyadorno/ipt/master/LICENSE)
-[![Join the chat at https://gitter.im/ipipeto/Lobby](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/ipipeto/Lobby)
+[![Join the chat at https://gitter.im/ipipeto/Lobby](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/ipipeto/Lobby) -->
 
-> Npm Task List
+> Yarn Task List
 
-Interactive cli menu to list and run npm tasks.
+Interactive cli menu to list and run npm tasks with [yarn](https://yarnpkg.com/en/).
+
+Fork of [ntl](https://github.com/ruyadorno/ntl) and work in progress. Documentation etc. might not be accurate or up to date.
 
 ![demo gif](http://i.imgur.com/ZjjQ7Vi.gif?1)
 
@@ -18,7 +20,7 @@ Interactive cli menu to list and run npm tasks.
 ## Install
 
 ```
-$ npm install -g ntl
+$ npm install -g ytl
 ```
 
 **OR**
@@ -26,7 +28,7 @@ $ npm install -g ntl
 just run it at once using **npx**:
 
 ```sh
-npx ntl
+npx ytl
 ```
 
 <br />
@@ -36,13 +38,13 @@ npx ntl
 **cd** to a folder containing a `package.json` files that has configured **scripts**, then:
 
 ```sh
-ntl
+ytl
 ```
 
 You can also specify a project folder containing a `package.json` file:
 
 ```sh
-ntl ./my-node-project
+ytl ./my-node-project
 ```
 
 <br />
@@ -56,7 +58,7 @@ Example *package.json*:
     "test": "jest --coverage",
     "test:watch": "jest --coverage --watchAll",
     "coveralls": "jest --coverage --coverageReporters=text-lcov | coveralls",
-    "tasks": "ntl --exclude coverall tasks"
+    "tasks": "ytl --exclude coverall tasks"
   }
 }
 ```
@@ -64,7 +66,7 @@ Example *package.json*:
 You can define a list of scripts to be excluded from the interactive menu:
 
 ```
-$ ntl --exclude coverall tasks
+$ ytl --exclude coverall tasks
 ✔  Npm Task List - v3.0.0
 ? Select a task to run: (Use arrow keys)
 ❯ test
@@ -75,7 +77,7 @@ $ ntl --exclude coverall tasks
 You can also use a wildcard character to exclude multiple scripts with one string:
 
 ```
-$ ntl --exclude "test*"
+$ ytl --exclude "test*"
 ✔  Npm Task List - v3.0.0
 ? Select a task to run: (Use arrow keys)
 ❯ coveralls
@@ -86,11 +88,11 @@ $ ntl --exclude "test*"
 
 ## Using task descriptions
 
-You can define descriptions for your tasks in your `package.json` file by defining a `ntl` section, e.g:
+You can define descriptions for your tasks in your `package.json` file by defining a `ytl` section, e.g:
 
 ```json
 {
-  "ntl": {
+  "ytl": {
     "descriptions": {
       "build": "Builds the project",
       "coverage": "Run test outputing code coverage",
@@ -100,7 +102,7 @@ You can define descriptions for your tasks in your `package.json` file by defini
 }
 ```
 
-These descriptions will be shown anytime you run ntl using the option: `ntl -d`
+These descriptions will be shown anytime you run ytl using the option: `ytl -d`
 
 <br />
 
@@ -120,10 +122,10 @@ cli options can also be invoked as their shorter alias:
 Here is what the help page looks like:
 
 ```sh
-ntl --help
+ytl --help
 
 Usage:
-  ntl [<path>]
+  ytl [<path>]
 
 Options:
   -a, --all                Includes pre and post scripts on the list   [boolean]
@@ -138,7 +140,7 @@ Options:
   -s, --size               Amount of lines to display at once           [number]
   -v, --version            Show version number                         [boolean]
 
-Visit https://github.com/ruyadorno/ntl for more info
+Visit https://github.com/Muldoser/ytl for more info
 ```
 
 <br />

--- a/cli.js
+++ b/cli.js
@@ -13,7 +13,7 @@ let descriptions;
 const sep = require("os").EOL;
 const { execSync } = require("child_process");
 const { argv } = yargs
-	.usage("Usage:\n  ntl [<path>]")
+	.usage("Usage:\n  ytl [<path>]")
 	.alias("a", "all")
 	.describe("a", "Includes pre and post scripts on the list")
 	.alias("A", "autocomplete")
@@ -39,7 +39,7 @@ const { argv } = yargs
 	.boolean(["a", "A", "D", "d", "o", "h", "i", "m", "v"])
 	.number(["s"])
 	.array(["e"])
-	.epilog("Visit https://github.com/ruyadorno/ntl for more info");
+	.epilog("Visit https://github.com/Muldoser/ytl for more info");
 
 const pkg = require("./package");
 const cwd = argv._[0] ? path.join(process.cwd(), argv._[0]) : process.cwd();
@@ -74,7 +74,7 @@ if (!tasks || Object.keys(tasks).length < 1) {
 // get package.json descriptions value
 if (argv.descriptions) {
 	try {
-		descriptions = readPkg.sync({ cwd: cwd }).ntl.descriptions;
+		descriptions = readPkg.sync({ cwd: cwd }).ytl.descriptions;
 	} catch (e) {
 		error(e, "No descriptions for your npm scripts found");
 	}
@@ -118,7 +118,7 @@ ipt(input, {
 })
 	.then(keys => {
 		keys.forEach(key => {
-			execSync(`npm run ${key}`, {
+			execSync(`yarn run ${key}`, {
 				cwd,
 				stdio: [process.stdin, process.stdout, process.stderr]
 			});

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
-  "name": "ntl",
-  "version": "3.2.4",
+  "name": "ytl",
+  "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1946,7 +1946,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -1967,12 +1968,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -1987,17 +1990,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -2114,7 +2120,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -2126,6 +2133,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -2140,6 +2148,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -2147,12 +2156,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -2171,6 +2182,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -2251,7 +2263,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -2263,6 +2276,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -2348,7 +2362,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -2384,6 +2399,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -2403,6 +2419,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -2446,12 +2463,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -3073,9 +3092,9 @@
       "dev": true
     },
     "js-yaml": {
-      "version": "3.12.2",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.2.tgz",
-      "integrity": "sha512-QHn/Lh/7HhZ/Twc7vJYQTkjuCa0kaCcDcjK5Zlk2rvnUpy7DxMJ23+Jc2dcyvltwQVg1nygAVlB2oRDFHoRS5Q==",
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
+      "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
       "dev": true,
       "requires": {
         "argparse": "^1.0.7",
@@ -3177,9 +3196,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.11",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
+      "version": "4.17.15",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
     },
     "lodash.clone": {
       "version": "4.5.0",
@@ -3230,9 +3249,9 @@
       "dev": true
     },
     "lodash.merge": {
-      "version": "4.6.1",
-      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.1.tgz",
-      "integrity": "sha512-AOYza4+Hf5z1/0Hztxpm2/xiPZgi/cjMqdnKTUWTBSKchJlxXXuUSxCCl8rJlf4g6yww/j6mA8nC8Hw/EZWxKQ==",
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true
     },
     "log-symbols": {
@@ -3434,9 +3453,9 @@
       }
     },
     "mixin-deep": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.1.tgz",
-      "integrity": "sha512-8ZItLHeEgaqEvd5lYBXfm4EZSFCX29Jb9K+lAHhDKzReKBQKj3R+7NOF6tjqYi9t4oI8VUfaWITJQm86wnXGNQ==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.2.tgz",
+      "integrity": "sha512-WRoDn//mXBiJ1H40rqa3vH0toePwSsGb45iInWlTySa+Uu4k3tYUSxa2v1KqAiLtvlrSzaExqS1gtk96A9zvEA==",
       "dev": true,
       "requires": {
         "for-in": "^1.0.2",
@@ -4399,9 +4418,9 @@
       "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
     },
     "set-value": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.0.tgz",
-      "integrity": "sha512-hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.1.tgz",
+      "integrity": "sha512-JxHc1weCN68wRY0fhCoXpyK55m/XPHafOmK4UWD7m2CI14GMcFypt4w/0+NV5f/ZMby2F6S2wwA7fgynh9gWSw==",
       "dev": true,
       "requires": {
         "extend-shallow": "^2.0.1",
@@ -5076,38 +5095,15 @@
       "dev": true
     },
     "union-value": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.0.tgz",
-      "integrity": "sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.1.tgz",
+      "integrity": "sha512-tJfXmxMeWYnczCVs7XAEvIV7ieppALdyepWMkHkwciRpZraG/xwT+s2JN8+pr1+8jCRf80FFzvr+MpQeeoF4Xg==",
       "dev": true,
       "requires": {
         "arr-union": "^3.1.0",
         "get-value": "^2.0.6",
         "is-extendable": "^0.1.1",
-        "set-value": "^0.4.3"
-      },
-      "dependencies": {
-        "extend-shallow": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-          "dev": true,
-          "requires": {
-            "is-extendable": "^0.1.0"
-          }
-        },
-        "set-value": {
-          "version": "0.4.3",
-          "resolved": "https://registry.npmjs.org/set-value/-/set-value-0.4.3.tgz",
-          "integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
-          "dev": true,
-          "requires": {
-            "extend-shallow": "^2.0.1",
-            "is-extendable": "^0.1.1",
-            "is-plain-object": "^2.0.1",
-            "to-object-path": "^0.3.0"
-          }
-        }
+        "set-value": "^2.0.1"
       }
     },
     "unique-string": {

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
-  "name": "ntl",
-  "version": "3.2.4",
-  "description": "Npm Task List: Interactive cli menu to list/run npm tasks",
-  "repository": "ruyadorno/ntl",
+  "name": "ytl",
+  "version": "1.0.0",
+  "description": "Yarn Task List: Interactive cli menu to list/run npm tasks with yarn",
+  "repository": "Muldoser/ytl",
   "author": {
     "name": "Ruy Adorno",
     "url": "http://ruyadorno.com"
@@ -19,6 +19,7 @@
     "cli.js"
   ],
   "keywords": [
+    "yarn",
     "npm",
     "task",
     "list",
@@ -27,6 +28,7 @@
     "cli-app",
     "cli",
     "ntl",
+    "ytl",
     "runner",
     "menu"
   ],

--- a/test/fixtures/package.json
+++ b/test/fixtures/package.json
@@ -10,7 +10,7 @@
     "start": "echo \"start\"",
     "test": "echo \"test\""
   },
-  "ntl": {
+  "ytl": {
     "descriptions": {
       "build": "Build task",
       "prestart": "Pre start task",

--- a/test/index.js
+++ b/test/index.js
@@ -60,7 +60,7 @@ test.cb('should work from cli', t => {
 			t.fail();
 		}
 		var values = content.split("\n");
-		t.is("build", values[values.length - 2]);
+		t.regex(values[values.length - 2], /Done in .*s./g);
 		t.end();
 	});
 	run.stdin.write("\n");
@@ -83,7 +83,7 @@ test.cb('should work from cli with path', t => {
 			t.fail();
 		}
 		var values = content.split("\n");
-		t.is("build", values[values.length - 2]);
+		t.regex(values[values.length - 2], /Done in .*s./g);
 		t.end();
 	});
 	run.stdin.write("\n");
@@ -106,7 +106,7 @@ test.cb('should work from cli with params', t => {
 			t.fail();
 		}
 		var values = content.split("\n");
-		t.is("debugger", values[values.length -2]);
+		t.regex(values[values.length -2], /Done in .*s./g);
 		t.end();
 	});
 	run.stdin.write("j");
@@ -164,7 +164,7 @@ test.cb('should exit with error msg on no package json', t => {
 				cwd: foldername
 			});
 			run.stderr.on("data", function(data) {
-				t.is(data.toString(), "✖  No package.json found\n");
+				t.regex(data.toString(), /.  No package.json found.*/g);
 				t.end();
 			});
 		})
@@ -178,7 +178,7 @@ test.cb('should exit with error msg on malformed package.json', t => {
 		cwd: path.join(__dirname, "/fixtures/malformed")
 	});
 	run.stderr.on("data", function(data) {
-		t.is(data.toString(), "✖  package.json contains malformed JSON\n");
+		t.regex(data.toString(), /.  package.json contains malformed JSON.*/g);
 		t.end();
 	});
 });


### PR DESCRIPTION
Use yarn instead of npm
Also alter tests so they can be run in windows (older version). Test failed because of different output from yarn or from UTF-8 characters that are not supported in old windows command prompts.